### PR TITLE
Work around edge case condition where key expires between _exist? and _get

### DIFF
--- a/lib/cache.rb
+++ b/lib/cache.rb
@@ -135,8 +135,9 @@ class Cache
   #     cache.fetch 'hello' { 'world' }
   def fetch(k, ttl = nil, &blk)
     handle_fork
-    if _exist? k
-      _get k
+    v = _get(k)
+    if !v.nil?
+      v
     elsif blk
       v = blk.call
       _set k, v, extract_ttl(ttl)


### PR DESCRIPTION
This was causing the cache to return  `nil` from time to time when the cache would expire between `_exist?` and `_get`.
